### PR TITLE
Add HassLens Connector integration

### DIFF
--- a/custom_components/hasslens_connector/__init__.py
+++ b/custom_components/hasslens_connector/__init__.py
@@ -1,0 +1,26 @@
+import logging
+from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import ConfigEntry
+
+from .const import DOMAIN
+from .api import HassLensConnectorAPI
+
+_LOGGER = logging.getLogger(__name__)
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up via YAML is not supported."""
+    return True
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up HassLens Connector from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = entry.data
+
+    hass.http.register_view(HassLensConnectorAPI(hass, entry))
+
+    return True
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Unload a config entry."""
+    hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
+    return True

--- a/custom_components/hasslens_connector/api.py
+++ b/custom_components/hasslens_connector/api.py
@@ -1,0 +1,46 @@
+import logging
+from aiohttp.web import Response
+from homeassistant.components.http import HomeAssistantView
+
+from .const import (
+    CONF_AUTOMATIONS_PATH,
+    CONF_SCRIPTS_PATH,
+    CONF_DEVICES_PATH,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+class HassLensConnectorAPI(HomeAssistantView):
+    """REST API to expose YAML files."""
+
+    url = "/api/hasslens_connector/{yaml_type}"
+    name = "api:hasslens_connector"
+    requires_auth = True
+
+    def __init__(self, hass, entry):
+        self.hass = hass
+        self.entry = entry
+
+    async def get(self, request, yaml_type):
+        key_map = {
+            "automations": CONF_AUTOMATIONS_PATH,
+            "scripts": CONF_SCRIPTS_PATH,
+            "devices": CONF_DEVICES_PATH,
+        }
+
+        if yaml_type not in key_map:
+            return Response(status=404, text="Invalid YAML type")
+
+        rel_path = self.entry.data.get(key_map[yaml_type])
+        abs_path = self.hass.config.path(rel_path)
+
+        try:
+            with open(abs_path, "r", encoding="utf-8") as file:
+                contents = file.read()
+        except FileNotFoundError:
+            return Response(status=404, text="File not found")
+        except Exception:  # noqa: broad-except
+            _LOGGER.exception("Failed to read %s", abs_path)
+            return Response(status=500, text="Internal server error")
+
+        return Response(text=contents, content_type="text/yaml")

--- a/custom_components/hasslens_connector/config_flow.py
+++ b/custom_components/hasslens_connector/config_flow.py
@@ -1,0 +1,30 @@
+import voluptuous as vol
+from homeassistant import config_entries
+
+from .const import (
+    DOMAIN,
+    CONF_AUTOMATIONS_PATH,
+    CONF_SCRIPTS_PATH,
+    CONF_DEVICES_PATH,
+)
+
+DEFAULTS = {
+    CONF_AUTOMATIONS_PATH: "automations.yaml",
+    CONF_SCRIPTS_PATH: "scripts.yaml",
+    CONF_DEVICES_PATH: "devices.yaml",
+}
+
+class HassLensConnectorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for HassLens Connector."""
+
+    async def async_step_user(self, user_input=None):
+        if user_input is not None:
+            return self.async_create_entry(title="HassLens Connector", data=user_input)
+
+        data_schema = vol.Schema({
+            vol.Required(CONF_AUTOMATIONS_PATH, default=DEFAULTS[CONF_AUTOMATIONS_PATH]): str,
+            vol.Required(CONF_SCRIPTS_PATH, default=DEFAULTS[CONF_SCRIPTS_PATH]): str,
+            vol.Required(CONF_DEVICES_PATH, default=DEFAULTS[CONF_DEVICES_PATH]): str,
+        })
+
+        return self.async_show_form(step_id="user", data_schema=data_schema)

--- a/custom_components/hasslens_connector/const.py
+++ b/custom_components/hasslens_connector/const.py
@@ -1,0 +1,4 @@
+DOMAIN = "hasslens_connector"
+CONF_AUTOMATIONS_PATH = "automations_path"
+CONF_SCRIPTS_PATH = "scripts_path"
+CONF_DEVICES_PATH = "devices_path"

--- a/custom_components/hasslens_connector/manifest.json
+++ b/custom_components/hasslens_connector/manifest.json
@@ -1,0 +1,9 @@
+{
+  "domain": "hasslens_connector",
+  "name": "HassLens Connector",
+  "version": "0.1.0",
+  "config_flow": true,
+  "requirements": [],
+  "documentation": "https://example.com",
+  "codeowners": ["@yourgithub"]
+}

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,7 @@
 {
   "name": "HassLens Connector",
   "content_in_root": false,
-  "domains": [ "hasslens" ],
+  "domains": ["hasslens_connector"],
   "country": "US",
   "homeassistant": "2022.0.0",
   "render_readme": true


### PR DESCRIPTION
## Summary
- add new `hasslens_connector` integration with config flow
- expose secured REST API to download configured YAML files
- register API view from the config entry
- update `hacs.json` domain

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c0f5d38e4832db63b7494d540af5b